### PR TITLE
fixed a bug. there was a case that failed parsing the output of "dir"…

### DIFF
--- a/src/Samba/SambaClient.php
+++ b/src/Samba/SambaClient.php
@@ -390,7 +390,7 @@ class SambaClient
                         : array($name, "workgroup", $master);
                     break;
                 case 'files':
-                    list ($attr, $name) = preg_match("/^(.*)[ ]+([D|A|H|S|R]+)$/", trim($regs[1]), $regs2)
+                    list ($attr, $name) = preg_match("/^(.*)[ ]+([V|D|A|H|S|N|R|d|t|s|r|c|o|n|e]+)$/", trim($regs[1]), $regs2)
                         ? array(trim($regs2[2]), trim($regs2[1]))
                         : array('', trim($regs[1]));
                     list ($his, $im) = array(


### PR DESCRIPTION
this patch is for covering all attributes.
this quote is from "libcli/smb/util.c"(samba-4.4.5).

``` c
        {'V', FILE_ATTRIBUTE_VOLUME},
        {'D', FILE_ATTRIBUTE_DIRECTORY},
        {'A', FILE_ATTRIBUTE_ARCHIVE},
        {'H', FILE_ATTRIBUTE_HIDDEN},
        {'S', FILE_ATTRIBUTE_SYSTEM},
        {'N', FILE_ATTRIBUTE_NORMAL},
        {'R', FILE_ATTRIBUTE_READONLY},
        {'d', FILE_ATTRIBUTE_DEVICE},
        {'t', FILE_ATTRIBUTE_TEMPORARY},
        {'s', FILE_ATTRIBUTE_SPARSE},
        {'r', FILE_ATTRIBUTE_REPARSE_POINT},
        {'c', FILE_ATTRIBUTE_COMPRESSED},
        {'o', FILE_ATTRIBUTE_OFFLINE},
        {'n', FILE_ATTRIBUTE_NONINDEXED},
        {'e', FILE_ATTRIBUTE_ENCRYPTED}
```
